### PR TITLE
Add Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ These Python bindings are available on [PyPI](https://pypi.python.org/pypi/hashp
             A tuple containing the new hex digest and the new message.
     >>> hashpumpy.hashpump('ffffffff', 'original_data', 'data_to_add', len('KEYKEYKEY'))
     ('e3c4a05f', 'original_datadata_to_add')
+
+### Python 3 note
+hashpumpy supports Python 3. Different from the Python 2 version, the returned tuple from `hashpumpy.hashpump` is a bytes-like object instead of a string.

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ These Python bindings are available on [PyPI](https://pypi.python.org/pypi/hashp
     ('e3c4a05f', 'original_datadata_to_add')
 
 ### Python 3 note
-hashpumpy supports Python 3. Different from the Python 2 version, the returned tuple from `hashpumpy.hashpump` is a bytes-like object instead of a string.
+hashpumpy supports Python 3. Different from the Python 2 version, the second value (the new message) in the returned tuple from `hashpumpy.hashpump` is a bytes-like object instead of a string.

--- a/hashpumpy.cpp
+++ b/hashpumpy.cpp
@@ -3,6 +3,21 @@
 #include <iomanip>
 #include "Extender.h"
 
+#define MODULE_NAME "hashpumpy"
+
+/* Definitions for Python2/3 compatibility */
+#if PY_MAJOR_VERSION >= 3
+#   define INITERROR return NULL
+#   define INITOK(m) return m
+#   define PyInit_Signature(name) PyInit_##name
+#   define BYTES_FORMAT "y#"
+#else
+#   define INITERROR return
+#   define INITOK(m) return
+#   define PyInit_Signature(name) init##name
+#   define BYTES_FORMAT "s#"
+#endif
+
 typedef unsigned char BYTE;
 
 vector<BYTE> StringToVector(BYTE * str);
@@ -121,7 +136,7 @@ hashpump(PyObject *self, PyObject *args)
     //
     // Return a tuple of (str, str)
     //
-    return Py_BuildValue("s#s#",
+    return Py_BuildValue("s#" BYTES_FORMAT,
                          new_digest.c_str(), new_digest.size(),
                          new_message.c_str(), new_message.size());
 }
@@ -144,17 +159,37 @@ static PyMethodDef HashpumpMethods[] = {
 };
 
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    MODULE_NAME,
+    NULL,
+    -1,
+    HashpumpMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+#endif
+
 PyMODINIT_FUNC
-inithashpumpy(void)
+PyInit_Signature(hashpumpy) (void)
 {
     PyObject *m;
 
-    m = Py_InitModule("hashpumpy", HashpumpMethods);
+#if PY_MAJOR_VERSION >= 3
+    m = PyModule_Create(&moduledef);
+#else
+    m = Py_InitModule(MODULE_NAME, HashpumpMethods);
+#endif
     if (m == NULL)
-        return;
+        INITERROR;
 
     HashpumpError = PyErr_NewException("hashpumpy.error", NULL, NULL);
     Py_INCREF(HashpumpError);
     PyModule_AddObject(m, "error", HashpumpError);
+
+    INITOK(m);
 }
 }

--- a/test.py
+++ b/test.py
@@ -1,9 +1,9 @@
 import hashpumpy
 import hashlib
 
-key           = "KEY"*4
-original_data = "ORIG"*4
-data_to_add   = "system('/bin/sh')"
+key           = b"KEY"*4
+original_data = b"ORIG"*4
+data_to_add   = b"system('/bin/sh')"
 
 for algorithm in (hashlib.md5, hashlib.sha1, hashlib.sha256, hashlib.sha512):
     original_digest      = algorithm(key + original_data).hexdigest()


### PR DESCRIPTION
I managed to make hashpumpy available for both Python 2 and Python 3 in this PR. Tested with Python 2.7.9/Python 3.2.5/Python 3.4.3 and GCC 5.1.0 on latest Arch Linux.
```
$ python2.7 test.py

$ python3.2 test.py

$ python3.4 test.py
```