### PR TITLE
don't install headers with Python module

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# Specifies extra files to include in the python sdist tarball
+# which will not be installed on the user's system
+include *.h

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup (name = 'hashpumpy',
        version = '1.2',
        author      = 'Zach Riggle (Python binding), Brian Wallace (HashPump), Yen Chi Hsuan (Python3 support)',
        description = 'Python bindings for HashPump',
-       data_files  = [('include', glob('*.h'))],
        ext_modules = [module1],
        license     = 'MIT',
        url         = 'https://github.com/bwall/HashPump')


### PR DESCRIPTION
This ensures that the header files are included in the sdist tarball that's uploaded to pypi but doesn't try to install the header files (which aren't needed at runtime) on the end user's system.