### PR TITLE
Fix bug in padding generation of SHA1, SHA256, SHA512

### DIFF
--- a/SHA1.cpp
+++ b/SHA1.cpp
@@ -59,10 +59,12 @@ vector<unsigned char> * SHA1ex::GenerateStretchedData(vector<unsigned char> orig
 	int tailLength = ret->size() + keylength;
 	tailLength *= 8;
 	ret->push_back(0x80);
-	while((ret->size() + keylength + 4) % 64 != 0)
+	while((ret->size() + keylength + 8) % 64 != 0)
 	{
 		ret->push_back(0x00);
 	}
+	for (int i = 0; i < 4; ++i)
+		ret->push_back(0x00);
 	ret->push_back((tailLength >> 24) & 0xFF);
 	ret->push_back((tailLength >> 16) & 0xFF);
 	ret->push_back((tailLength >> 8) & 0xFF);

--- a/SHA256.cpp
+++ b/SHA256.cpp
@@ -64,10 +64,12 @@ vector<unsigned char> * SHA256ex::GenerateStretchedData(vector<unsigned char> or
 	int tailLength = ret->size() + keylength;
 	tailLength *= 8;
 	ret->push_back(0x80);
-	while((ret->size() + keylength + 4) % 64 != 0)
+	while((ret->size() + keylength + 8) % 64 != 0)
 	{
 		ret->push_back(0x00);
 	}
+	for (int i = 0; i < 4; ++i)
+		ret->push_back(0x00);
 	ret->push_back((tailLength >> 24) & 0xFF);
 	ret->push_back((tailLength >> 16) & 0xFF);
 	ret->push_back((tailLength >> 8) & 0xFF);

--- a/SHA512ex.cpp
+++ b/SHA512ex.cpp
@@ -63,10 +63,12 @@ vector<unsigned char> * SHA512ex::GenerateStretchedData(vector<unsigned char> or
 	int tailLength = ret->size() + keylength;
 	tailLength *= 8;
 	ret->push_back(0x80);
-	while((ret->size() + keylength + 4) % 128 != 0)
+	while((ret->size() + keylength + 16) % 128 != 0)
 	{
 		ret->push_back(0x00);
 	}
+	for (int i = 0; i < 12; ++i)
+		ret->push_back(0x00);
 	ret->push_back((tailLength >> 24) & 0xFF);
 	ret->push_back((tailLength >> 16) & 0xFF);
 	ret->push_back((tailLength >> 8) & 0xFF);


### PR DESCRIPTION
The test is not complete. You can find out this bug when you use the following test code.
```python
import hashpumpy
import urllib
import hashlib

for i in xrange(200):
    key           = b"K" * i
    original_data = b"a"
    data_to_add   = b"a"

    for algorithm in (hashlib.sha1, hashlib.sha256, hashlib.sha512, ):
        original_digest      = algorithm(key + original_data).hexdigest()
        new_digest, new_data = hashpumpy.hashpump(original_digest, original_data, data_to_add, len(key))
        verify_digest        = algorithm(key + new_data).hexdigest()

        if new_digest != verify_digest:
            print len(key + original_data), repr(new_data), algorithm
```

```
56 'a\x80\x00\x00\x00\x00\x00\x01\xc0a' <built-in function openssl_sha1>
56 'a\x80\x00\x00\x00\x00\x00\x01\xc0a' <built-in function openssl_sha256>
57 'a\x80\x00\x00\x00\x00\x01\xc8a' <built-in function openssl_sha1>
57 'a\x80\x00\x00\x00\x00\x01\xc8a' <built-in function openssl_sha256>
58 'a\x80\x00\x00\x00\x01\xd0a' <built-in function openssl_sha1>
58 'a\x80\x00\x00\x00\x01\xd0a' <built-in function openssl_sha256>
59 'a\x80\x00\x00\x01\xd8a' <built-in function openssl_sha1>
59 'a\x80\x00\x00\x01\xd8a' <built-in function openssl_sha256>
112 'a\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x80a' <built-in function openssl_sha512>
113 'a\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x88a' <built-in function openssl_sha512>
114 'a\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x90a' <built-in function openssl_sha512>
115 'a\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x98a' <built-in function openssl_sha512>
116 'a\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\xa0a' <built-in function openssl_sha512>
117 'a\x80\x00\x00\x00\x00\x00\x00\x00\x00\x03\xa8a' <built-in function openssl_sha512>
118 'a\x80\x00\x00\x00\x00\x00\x00\x00\x03\xb0a' <built-in function openssl_sha512>
119 'a\x80\x00\x00\x00\x00\x00\x00\x03\xb8a' <built-in function openssl_sha512>
120 'a\x80\x00\x00\x00\x00\x00\x03\xc0a' <built-in function openssl_sha1>
120 'a\x80\x00\x00\x00\x00\x00\x03\xc0a' <built-in function openssl_sha256>
120 'a\x80\x00\x00\x00\x00\x00\x03\xc0a' <built-in function openssl_sha512>
121 'a\x80\x00\x00\x00\x00\x03\xc8a' <built-in function openssl_sha1>
121 'a\x80\x00\x00\x00\x00\x03\xc8a' <built-in function openssl_sha256>
121 'a\x80\x00\x00\x00\x00\x03\xc8a' <built-in function openssl_sha512>
122 'a\x80\x00\x00\x00\x03\xd0a' <built-in function openssl_sha1>
122 'a\x80\x00\x00\x00\x03\xd0a' <built-in function openssl_sha256>
122 'a\x80\x00\x00\x00\x03\xd0a' <built-in function openssl_sha512>
123 'a\x80\x00\x00\x03\xd8a' <built-in function openssl_sha1>
123 'a\x80\x00\x00\x03\xd8a' <built-in function openssl_sha256>
123 'a\x80\x00\x00\x03\xd8a' <built-in function openssl_sha512>
184 'a\x80\x00\x00\x00\x00\x00\x05\xc0a' <built-in function openssl_sha1>
184 'a\x80\x00\x00\x00\x00\x00\x05\xc0a' <built-in function openssl_sha256>
185 'a\x80\x00\x00\x00\x00\x05\xc8a' <built-in function openssl_sha1>
185 'a\x80\x00\x00\x00\x00\x05\xc8a' <built-in function openssl_sha256>
186 'a\x80\x00\x00\x00\x05\xd0a' <built-in function openssl_sha1>
186 'a\x80\x00\x00\x00\x05\xd0a' <built-in function openssl_sha256>
187 'a\x80\x00\x00\x05\xd8a' <built-in function openssl_sha1>
187 'a\x80\x00\x00\x05\xd8a' <built-in function openssl_sha256>
```

The problem is the size of length in SHA1 is 8 byte. It should create a new block for padding if `size % 64 >= 56`, but origin code will do that when `>= 60`. The same issue also happened in SHA256 and SHA512.

Ref.
* [SHA specs (fips180-2)](http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf)

