### PR TITLE
Extra check is not needed

### DIFF
--- a/hashpumpy.cpp
+++ b/hashpumpy.cpp
@@ -61,12 +61,6 @@ hashpump(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if(0 == original_data_size)
-    {
-        PyErr_SetString(HashpumpError, "original_data is empty");
-        return NULL;
-    }
-
     if(0 == data_to_add_size)
     {
         PyErr_SetString(HashpumpError, "data_to_add is empty");


### PR DESCRIPTION
hashpump function requires that the original_data argument be nonempty, so this condition check is unnecessary, since it works with empty strings