### PR TITLE
Fix SystemError on Python 3.10 and later

### DIFF
--- a/hashpumpy.cpp
+++ b/hashpumpy.cpp
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <sstream>
 #include <iomanip>


### PR DESCRIPTION
Was updating Homebrew formula to Python 3.11 but noticed that the Python bindings were broken since previous update to Python 3.10. Using them produces an error:
```
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
```

Ref: https://docs.python.org/3.10/c-api/intro.html#include-files
> It is recommended to always define `PY_SSIZE_T_CLEAN` before including `Python.h`

