### PR TITLE
Update hashpumpy to work with python3.10

### DIFF
--- a/hashpumpy.cpp
+++ b/hashpumpy.cpp
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <sstream>
 #include <iomanip>


### PR DESCRIPTION
Hashpumpy currently does not work on Python 3.10, due to the issue explained in [this StackOverflow answer](https://stackoverflow.com/a/71019907). Adding one line to the beginning of `hashpumpy.cpp` seems to fix this; I haven't tested it with older versions of Python but I can't imagine defining a macro would break anything.